### PR TITLE
Removing shinyalert size argument

### DIFF
--- a/server.R
+++ b/server.R
@@ -88,7 +88,7 @@ server <- function(input, output, session) {
     shinyalert(
       title = "Did you mean...",
       text = paste0(msg, "  ?"),
-      size = "xs",
+      # size = "xs",
       closeOnEsc = TRUE,
       closeOnClickOutside = TRUE,
       html = FALSE,


### PR DESCRIPTION
The version of `shinyalert` available does not have the "size" argument available, so it was causing the app to crash whenever the button to trigger the alert was selected. Removing the size argument - the alert popup window will be a little larger than before, but otherwise there should be no functional changes.