### PR TITLE
NUP98 Fusion Partner Splitting

### DIFF
--- a/global.R
+++ b/global.R
@@ -61,7 +61,7 @@ readData <- function(x) {
 
   # Clinical data
   load("data/Clinical/Beat_AML_Supplementary_ClinicalData_FinalforShiny.RData", .GlobalEnv)
-  load("data/Clinical/TARGET_AML_merged_CDEs_Shareable_FinalforShiny_Updated_08_28_24_NA.RData", .GlobalEnv)
+  load("data/Clinical/TARGET_AML_merged_CDEs_Shareable_FinalforShiny_Updated_12_17_24.RData", .GlobalEnv)
   load("data/Clinical/SWOG_AML_Merged_CDEs_FinalforShiny.RData", .GlobalEnv)
   load("data/Clinical/TCGA_LAML_ClinicalData_FinalforShiny.RData", .GlobalEnv)
   load("data/Clinical/StJude_ALL_ClinicalData_FinalforShiny.RData", .GlobalEnv)

--- a/waterfallPlot_module.R
+++ b/waterfallPlot_module.R
@@ -404,8 +404,10 @@ wfPlot <- function(input, output, session, clinData, expData, adc_cart_targetDat
               legend.position = "bottom",
               legend.text = element_text(size = bs - 6),
               legend.title = element_blank()) +
+
         guides(color = "none") 
         
+
       # Try to convert to a plotly plot with interactive tooltips
       p <- ggplotly(p, tooltip = c("y", "color"), dynamicTicks = TRUE)
 


### PR DESCRIPTION
Updated global.R to read in new clinical sheet for TARGET cohort. Updated the column mapping file and target cohort clinical data on AWS to allow for splitting of NUP98 fused AML by fusion partner. 